### PR TITLE
Specify PostGIS 3.4

### DIFF
--- a/docs/source/installation/installation.rst
+++ b/docs/source/installation/installation.rst
@@ -29,7 +29,8 @@ Database Configuration
 =========================================
 A. External users: Create your database
 ----------------------------------------
-- Install PostgreSQL on your machine.
+- Install `PostgreSQL 16 <https://www.postgresql.org/download/>`_ on your machine and make sure to keep "Stack Builder" checked.
+- Using Stack Builder install **PostGIS 3.4**.
 - Create your database with the appropriate configuration (dbname, user, password, host, port).
 - Create a ``.env`` file in the root directory of the repository with these configurations or adjust the connections parameters in the ``config_data.py``.
 - Your configurations might might look like this:

--- a/executable_scripts/main_constructor.py
+++ b/executable_scripts/main_constructor.py
@@ -1,6 +1,7 @@
 """
 This script creates a pylovo database and fills with raw data from referenced files.
 Do not use SyngridDatabaseConstructor unless you want to create a new database.
+Make sure to have PostGIS 3.4 installed, newer versions lead to errors.
 """
 
 from raw_data.municipal_register.join_regiostar_gemeindeverz import create_municipal_register


### PR DESCRIPTION
Using PostGIS 3.5 leads to errors in grid generation. Therefore, PostGIS 3.4 should be used to setup the project.