### PR TITLE
Improve grid_generation_for_multiple_plz performance

### DIFF
--- a/pylovo/pgReaderWriter.py
+++ b/pylovo/pgReaderWriter.py
@@ -2072,11 +2072,11 @@ class PgReaderWriter:
         self.cur.execute(query, vars={"p": plz})
 
         # Clear temporary tables
-        query = """DELETE FROM buildings_tem"""
+        query = """TRUNCATE TABLE buildings_tem"""
         self.cur.execute(query)
-        query = """DELETE FROM ways_tem"""
+        query = """TRUNCATE TABLE ways_tem"""
         self.cur.execute(query)
-        query = """DELETE FROM ways_tem_vertices_pgr"""
+        query = """TRUNCATE TABLE ways_tem_vertices_pgr"""
         self.cur.execute(query)
 
         self.conn.commit()


### PR DESCRIPTION
## Description

In this PR, the temporary table cleanup logic has been improved by replacing `DELETE FROM` statements with `TRUNCATE TABLE`. 

This change improves the performance of `grid_generation_for_multiple_plz`, since `TRUNCATE TABLE` is significantly faster for clearing entire tables compared to `DELETE`, which logs each row deletion and can cause higher overhead.

Discussion about this task can be seen in [issue#22](https://github.com/tum-ens/pylovo/issues/22).
