### PR TITLE
feature/37-add-schema-selection-to-database-connection-configuration

### DIFF
--- a/classification/database_communication/DatabaseCommunication.py
+++ b/classification/database_communication/DatabaseCommunication.py
@@ -3,6 +3,7 @@ import pandas as pd
 import psycopg2 as pg
 from geoalchemy2 import Geometry, WKTElement
 from sqlalchemy import create_engine
+from pylovo import pgReaderWriter as pg
 
 from classification.clustering.clustering_algorithms import *
 from pylovo.config_loader import *
@@ -15,12 +16,10 @@ class DatabaseCommunication:
     """
 
     def __init__(self, **kwargs):
-        self.conn = pg.connect(
-            database=DBNAME, user=USER, password=PASSWORD, host=HOST, port=PORT
-        )
-        self.cur = self.conn.cursor()
-        self.db_path = f"postgresql+psycopg2://{USER}:{PASSWORD}@{HOST}:{PORT}/{DBNAME}"
-        self.sqla_engine = create_engine(self.db_path)
+        self.pg = pg.PgReaderWriter()
+        self.cur = self.pg.cur
+        self.conn= self.pg.conn
+        self.sqla_engine= self.pg.sqla_engine
 
         print("Database connection is constructed. ")
 

--- a/classification/database_communication/DatabaseCommunication.py
+++ b/classification/database_communication/DatabaseCommunication.py
@@ -16,16 +16,13 @@ class DatabaseCommunication:
     """
 
     def __init__(self, **kwargs):
-        self.pg = pg.PgReaderWriter()
-        self.cur = self.pg.cur
-        self.conn= self.pg.conn
-        self.sqla_engine= self.pg.sqla_engine
+        self.pgr = pg.PgReaderWriter()
 
         print("Database connection is constructed. ")
 
     def __del__(self):
-        self.cur.close()
-        self.conn.close()
+        self.pgr.cur.close()
+        self.pgr.conn.close()
         print("Database connection closed.")
 
     def get_clustering_parameters_for_plz(self, plz: str) -> pd.DataFrame:
@@ -40,7 +37,7 @@ class DatabaseCommunication:
                 JOIN grid_result gr ON cp.grid_result_id = gr.grid_result_id
                 WHERE gr.version_id = %(v)s AND gr.plz = %(p)s;"""
         params = {"v": VERSION_ID, "p": plz}
-        df_query = pd.read_sql_query(query, con=self.conn, params=params, )
+        df_query = pd.read_sql_query(query, con=self.pgr.conn, params=params, )
         columns = CLUSTERING_PARAMETERS
         df_parameter = pd.DataFrame(df_query, columns=columns)
         return df_parameter
@@ -68,7 +65,7 @@ class DatabaseCommunication:
                 JOIN plz_table p
                 ON c.plz = p.plz;"""
         params = {"v": VERSION_ID, "c": CLASSIFICATION_VERSION}
-        df_query = pd.read_sql_query(query, con=self.conn, params=params, )
+        df_query = pd.read_sql_query(query, con=self.pgr.conn, params=params, )
         columns = CLUSTERING_PARAMETERS
         df_parameter = pd.DataFrame(df_query, columns=columns)
         return df_parameter
@@ -102,7 +99,7 @@ class DatabaseCommunication:
                 JOIN plz_table p
                 ON c.plz = p.plz;"""
         params = {"v": VERSION_ID, "c": CLASSIFICATION_VERSION}
-        df_query = pd.read_sql_query(query, con=self.conn, params=params, )
+        df_query = pd.read_sql_query(query, con=self.pgr.conn, params=params, )
         return df_query
 
     def create_wkt_element(self, geom):
@@ -123,7 +120,7 @@ class DatabaseCommunication:
                   ON tp.grid_result_id = gr.grid_result_id
                 WHERE version_id=%(v)s;"""
         params = {"v": VERSION_ID}
-        df_transformer_positions = gpd.read_postgis(query, con=self.sqla_engine, params=params, )
+        df_transformer_positions = gpd.read_postgis(query, con=self.pgr.sqla_engine, params=params, )
         df_transformer_positions['geom'] = df_transformer_positions['geom'].apply(self.create_wkt_element)
 
         # calculate the clusters
@@ -181,7 +178,7 @@ class DatabaseCommunication:
                 FROM grid_result
                 WHERE version_id=%(v)s;"""
         params = {"v": VERSION_ID}
-        df_grid_result = pd.read_sql_query(query, con=self.sqla_engine, params=params)
+        df_grid_result = pd.read_sql_query(query, con=self.pgr.sqla_engine, params=params)
 
         df_transformers_classified  = pd.merge(df_grid_result, df_transformers_classified, how='right',
                                                left_on=['version_id', 'plz', 'kcid', 'bcid'],
@@ -192,11 +189,11 @@ class DatabaseCommunication:
         # add classification id
         df_transformers_classified['classification_id'] = CLASSIFICATION_VERSION
         # write transformer data with cluster info to database
-        df_transformers_classified.to_sql(name='transformer_classified', con=self.sqla_engine,
+        df_transformers_classified.to_sql(name='transformer_classified', con=self.pgr.sqla_engine,
                                           if_exists='append',
                                           index=False, dtype={'geom': Geometry(geometry_type='POINT', srid=3035)})
-        print(self.cur.statusmessage)
-        self.conn.commit()
+        print(self.pgr.cur.statusmessage)
+        self.pgr.conn.commit()
 
     def apply_max_trafo_dis_threshold(self) -> None:
         """apply maximum transformer distance threshold on clustering parameter table
@@ -205,9 +202,9 @@ class DatabaseCommunication:
         query = """UPDATE clustering_parameters
                 SET filtered = true
                 WHERE max_trafo_dis > %(t)s;"""
-        self.cur.execute(query, {"t": THRESHOLD_MAX_TRAFO_DIS})
-        print(self.cur.statusmessage)
-        self.conn.commit()
+        self.pgr.cur.execute(query, {"t": THRESHOLD_MAX_TRAFO_DIS})
+        print(self.pgr.cur.statusmessage)
+        self.pgr.conn.commit()
 
     def apply_households_per_building_threshold(self) -> None:
         """apply maximum households per building threshold on clustering parameter table
@@ -223,9 +220,9 @@ class DatabaseCommunication:
                    SET filtered = true
                    FROM buildings b
                    WHERE c.grid_result_id = b.grid_result_id;"""
-        self.cur.execute(query, {"h": THRESHOLD_HOUSEHOLDS_PER_BUILDING})
-        print(self.cur.statusmessage)
-        self.conn.commit()
+        self.pgr.cur.execute(query, {"h": THRESHOLD_HOUSEHOLDS_PER_BUILDING})
+        print(self.pgr.cur.statusmessage)
+        self.pgr.conn.commit()
     
     def apply_list_of_clustering_parameters_thresholds(self) -> None:
         """
@@ -249,9 +246,9 @@ class DatabaseCommunication:
             "no_households": THRESHOLD_NO_HOUSEHOLDS
         }
 
-        self.cur.execute(query, params)
-        print(self.cur.statusmessage)
-        self.conn.commit()
+        self.pgr.cur.execute(query, params)
+        print(self.pgr.cur.statusmessage)
+        self.pgr.conn.commit()
 
     def set_remaining_filter_values_false(self) -> None:
         """setting filtered value to false for grids that should not be filtered according to their parameters
@@ -259,9 +256,9 @@ class DatabaseCommunication:
         query = """UPDATE clustering_parameters 
             SET filtered = false
             WHERE filtered IS NULL;"""
-        self.cur.execute(query)
-        print(self.cur.statusmessage)
-        self.conn.commit()
+        self.pgr.cur.execute(query)
+        print(self.pgr.cur.statusmessage)
+        self.pgr.conn.commit()
 
     def get_ags_for_plz(df_plz: pd.DataFrame) -> pd.DataFrame:
         """get the AGS for the PLZ in a dataframe

--- a/classification/parameter_calculation/GridParameters.py
+++ b/classification/parameter_calculation/GridParameters.py
@@ -18,7 +18,7 @@ class GridParameters:
     """
 
     def __init__(self, plz, bcid, kcid, pgReaderWriter):
-        self.pg = pgReaderWriter
+        self.pgr = pgReaderWriter
         self.version_id = VERSION_ID
         self.plz = plz
         self.bcid = bcid
@@ -53,7 +53,7 @@ class GridParameters:
         self.osm_trafo = self.has_osm_trafo()
 
         # load network
-        net = self.pg.read_net(self.plz, self.kcid, self.bcid)
+        net = self.pgr.read_net(self.plz, self.kcid, self.bcid)
 
         # calculate parameters
         self.compute_parameters(net)
@@ -151,7 +151,7 @@ class GridParameters:
         # in data list at index 2 the simultaneous
         # peak load is saved grouped by transformer size
         # see also compare_grid_parameters_db.iynb for more details
-        data_list, data_labels, trafo_dict = self.pg.read_per_trafo_dict(self.plz)
+        data_list, data_labels, trafo_dict = self.pgr.read_per_trafo_dict(self.plz)
         transformer_type_str = str(int(self.transformer_mva * 1000))
         max_trafo_distance_list = data_list[3][transformer_type_str]
         if self.max_trafo_dis * 1000 in max_trafo_distance_list:
@@ -273,7 +273,7 @@ class GridParameters:
                   %(ratio)s,
                   %(vsw_per_branch)s,
                   %(max_vsw_of_a_branch)s);"""
-        self.pg.cur.execute(query, {
+        self.pgr.cur.execute(query, {
             "version_id": self.version_id,
             "plz": self.plz,
             "bcid": self.bcid,
@@ -301,8 +301,8 @@ class GridParameters:
             "vsw_per_branch": float(self.vsw_per_branch),
             "max_vsw_of_a_branch": float(self.max_vsw_of_a_branch)
         })
-        print(self.pg.cur.statusmessage)
-        self.pg.conn.commit()
+        print(self.pgr.cur.statusmessage)
+        self.pgr.conn.commit()
 
 
 def get_max_power(pandapower_net) -> float:

--- a/classification/parameter_calculation/GridParameters.py
+++ b/classification/parameter_calculation/GridParameters.py
@@ -224,8 +224,6 @@ class GridParameters:
 
     def write_parameters_to_db(self):
         """writes parameters to database"""
-        conn = psycopg2.connect(database=DBNAME, user=USER, password=PASSWORD, host=HOST, port=PORT)
-        cur = conn.cursor()
         query = """INSERT INTO clustering_parameters (
                    grid_result_id,
                    no_connection_buses,
@@ -275,7 +273,7 @@ class GridParameters:
                   %(ratio)s,
                   %(vsw_per_branch)s,
                   %(max_vsw_of_a_branch)s);"""
-        cur.execute(query, {
+        self.pg.cur.execute(query, {
             "version_id": self.version_id,
             "plz": self.plz,
             "bcid": self.bcid,
@@ -303,8 +301,8 @@ class GridParameters:
             "vsw_per_branch": float(self.vsw_per_branch),
             "max_vsw_of_a_branch": float(self.max_vsw_of_a_branch)
         })
-        print(cur.statusmessage)
-        conn.commit()
+        print(self.pg.cur.statusmessage)
+        self.pg.conn.commit()
 
 
 def get_max_power(pandapower_net) -> float:

--- a/classification/parameter_calculation/ParameterCalculator.py
+++ b/classification/parameter_calculation/ParameterCalculator.py
@@ -7,7 +7,7 @@ class ParameterCalculator:
     def __init__(self, plz):
         self.plz = plz
         # connect to database
-        self.pg = pg.PgReaderWriter()
+        self.pgr = pg.PgReaderWriter()
         
 
     def calc_parameters_for_grids(self) -> None:
@@ -15,15 +15,15 @@ class ParameterCalculator:
         this function extracts and calculates parameters for each net in a plz
         """
         # check if for this version ID and PLZ the parameters have already been calculated
-        parameter_count = self.pg.count_clustering_parameters(plz=self.plz)
+        parameter_count = self.pgr.count_clustering_parameters(plz=self.plz)
         if parameter_count > 0:
             print(f"The parameters for the grids of postcode area {self.plz} and version {VERSION_ID} "
                   f"have already been calculated.")
             return
         # all nets within plz
-        cluster_list = self.pg.get_list_from_plz(self.plz)
+        cluster_list = self.pgr.get_list_from_plz(self.plz)
         # loop over all networks
         for kcid, bcid in cluster_list:
-            gp = GridParameters(self.plz, bcid, kcid, self.pg)
+            gp = GridParameters(self.plz, bcid, kcid, self.pgr)
             print(bcid, kcid)
             gp.calc_plz_parameters()

--- a/classification/parameter_calculation/ParameterCalculator.py
+++ b/classification/parameter_calculation/ParameterCalculator.py
@@ -1,5 +1,5 @@
 from classification.parameter_calculation.GridParameters import GridParameters
-from pylovo.GridGenerator import GridGenerator
+from pylovo import pgReaderWriter as pg
 from pylovo.config_loader import VERSION_ID
 
 
@@ -7,8 +7,8 @@ class ParameterCalculator:
     def __init__(self, plz):
         self.plz = plz
         # connect to database
-        self.gg = GridGenerator(plz=plz)
-        self.pg = self.gg.pgr
+        self.pg = pg.PgReaderWriter()
+        
 
     def calc_parameters_for_grids(self) -> None:
         """

--- a/classification/sampling/sample.py
+++ b/classification/sampling/sample.py
@@ -194,8 +194,8 @@ def get_sample_set() -> pd.DataFrame:
         f"postgresql+psycopg2://{USER}:{PASSWORD}@{HOST}:{PORT}/{DBNAME}")
     cur = conn.cursor()
     query = f"""SELECT ss.plz, mr.pop, mr.area, mr.lat, mr.lon, ss.ags, mr.name_city, mr.fed_state, mr.regio7, mr.regio5, mr.pop_den
-    FROM public.sample_set ss
-    JOIN public.municipal_register mr ON ss.plz = mr.plz AND ss.ags = mr.ags
+    FROM {TARGET_SCHEMA}.sample_set ss
+    JOIN {TARGET_SCHEMA}.municipal_register mr ON ss.plz = mr.plz AND ss.ags = mr.ags
     WHERE ss.classification_id = {CLASSIFICATION_VERSION};"""
     cur.execute(query)
     sample_set = cur.fetchall()

--- a/classification/sampling/sample.py
+++ b/classification/sampling/sample.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import psycopg2
 from sqlalchemy import create_engine
+from pylovo import pgReaderWriter as pg
 
 from pylovo.config_loader import *
 from pylovo.GridGenerator import GridGenerator
@@ -19,6 +20,7 @@ samples_per_class_pop = {
     77: 16,
 }
 
+pg = pg.PgReaderWriter()
 
 def check_if_classification_version_exists():
     """checks whether classification version already exists.
@@ -26,10 +28,7 @@ def check_if_classification_version_exists():
 
     :raises Exception: if classification version already exists
     """
-    conn = psycopg2.connect(database=DBNAME, user=USER, password=PASSWORD, host=HOST, port=PORT)
-    sqlalchemy_engine = create_engine(
-        f"postgresql+psycopg2://{USER}:{PASSWORD}@{HOST}:{PORT}/{DBNAME}")
-    cur = conn.cursor()
+    cur = pg.cur
     count_query = f"""SELECT COUNT(*) 
             FROM classification_version 
             WHERE "classification_id" = {CLASSIFICATION_VERSION}"""
@@ -46,7 +45,7 @@ def check_if_classification_version_exists():
         ({CLASSIFICATION_VERSION}, '{CLASSIFICATION_VERSION_COMMENT}', '{CLASSIFICATION_REGION}')"""
         cur.execute(insert_query)
         print(cur.statusmessage)
-        conn.commit()
+        pg.conn.commit()
         print(f"Classification version: {CLASSIFICATION_VERSION} was added")
 
 
@@ -56,8 +55,6 @@ def get_municipal_register_as_dataframe() -> pd.DataFrame:
     :return: municipal register
     :rtype: pd.DataFrame
     """
-    gg = GridGenerator(plz='85375')
-    pg = gg.pgr
     regiostar_plz = pg.get_municipal_register()
     return regiostar_plz
 
@@ -134,13 +131,10 @@ def sample_set_to_db(regiostar_samples_result: pd.DataFrame):
     :type regiostar_samples_result: pd.DataFrame
 
     """
-    conn = psycopg2.connect(database=DBNAME, user=USER, password=PASSWORD, host=HOST, port=PORT)
-    sqlalchemy_engine = create_engine(
-        f"postgresql+psycopg2://{USER}:{PASSWORD}@{HOST}:{PORT}/{DBNAME}")
-    cur = conn.cursor()
-    regiostar_samples_result.to_sql('sample_set', con=sqlalchemy_engine, if_exists='append', index=False)
+    cur = pg.cur
+    regiostar_samples_result.to_sql('sample_set', con=pg.sqla_engine, if_exists='append', index=False)
     print(cur.statusmessage)
-    conn.commit()
+    pg.conn.commit()
 
 
 def get_federal_state_id() -> int:
@@ -189,13 +183,10 @@ def get_sample_set() -> pd.DataFrame:
     :return: table of a complete sample set
     :rtype: pd.DataFrame
     """
-    conn = psycopg2.connect(database=DBNAME, user=USER, password=PASSWORD, host=HOST, port=PORT)
-    sqlalchemy_engine = create_engine(
-        f"postgresql+psycopg2://{USER}:{PASSWORD}@{HOST}:{PORT}/{DBNAME}")
-    cur = conn.cursor()
+    cur = pg.cur
     query = f"""SELECT ss.plz, mr.pop, mr.area, mr.lat, mr.lon, ss.ags, mr.name_city, mr.fed_state, mr.regio7, mr.regio5, mr.pop_den
-    FROM {TARGET_SCHEMA}.sample_set ss
-    JOIN {TARGET_SCHEMA}.municipal_register mr ON ss.plz = mr.plz AND ss.ags = mr.ags
+    FROM sample_set ss
+    JOIN municipal_register mr ON ss.plz = mr.plz AND ss.ags = mr.ags
     WHERE ss.classification_id = {CLASSIFICATION_VERSION};"""
     cur.execute(query)
     sample_set = cur.fetchall()

--- a/classification/sampling/sample.py
+++ b/classification/sampling/sample.py
@@ -20,7 +20,7 @@ samples_per_class_pop = {
     77: 16,
 }
 
-pg = pg.PgReaderWriter()
+pgr = pg.PgReaderWriter()
 
 def check_if_classification_version_exists():
     """checks whether classification version already exists.
@@ -28,7 +28,7 @@ def check_if_classification_version_exists():
 
     :raises Exception: if classification version already exists
     """
-    cur = pg.cur
+    cur = pgr.cur
     count_query = f"""SELECT COUNT(*) 
             FROM classification_version 
             WHERE "classification_id" = {CLASSIFICATION_VERSION}"""
@@ -45,7 +45,7 @@ def check_if_classification_version_exists():
         ({CLASSIFICATION_VERSION}, '{CLASSIFICATION_VERSION_COMMENT}', '{CLASSIFICATION_REGION}')"""
         cur.execute(insert_query)
         print(cur.statusmessage)
-        pg.conn.commit()
+        pgr.conn.commit()
         print(f"Classification version: {CLASSIFICATION_VERSION} was added")
 
 
@@ -55,7 +55,7 @@ def get_municipal_register_as_dataframe() -> pd.DataFrame:
     :return: municipal register
     :rtype: pd.DataFrame
     """
-    regiostar_plz = pg.get_municipal_register()
+    regiostar_plz = pgr.get_municipal_register()
     return regiostar_plz
 
 
@@ -131,10 +131,10 @@ def sample_set_to_db(regiostar_samples_result: pd.DataFrame):
     :type regiostar_samples_result: pd.DataFrame
 
     """
-    cur = pg.cur
-    regiostar_samples_result.to_sql('sample_set', con=pg.sqla_engine, if_exists='append', index=False)
+    cur = pgr.cur
+    regiostar_samples_result.to_sql('sample_set', con=pgr.sqla_engine, if_exists='append', index=False)
     print(cur.statusmessage)
-    pg.conn.commit()
+    pgr.conn.commit()
 
 
 def get_federal_state_id() -> int:
@@ -183,7 +183,7 @@ def get_sample_set() -> pd.DataFrame:
     :return: table of a complete sample set
     :rtype: pd.DataFrame
     """
-    cur = pg.cur
+    cur = pgr.cur
     query = f"""SELECT ss.plz, mr.pop, mr.area, mr.lat, mr.lon, ss.ags, mr.name_city, mr.fed_state, mr.regio7, mr.regio5, mr.pop_den
     FROM sample_set ss
     JOIN municipal_register mr ON ss.plz = mr.plz AND ss.ags = mr.ags

--- a/classification/utils/get_average_values_clustering_parameters.py
+++ b/classification/utils/get_average_values_clustering_parameters.py
@@ -46,10 +46,10 @@ def get_clustering_parameters_for_kmeans_cluster_0() -> pd.DataFrame:
         # Run the query
         query = f"""
             SELECT cp.*
-            FROM {TARGET_SCHEMA}.clustering_parameters cp
+            FROM clustering_parameters cp
             JOIN (
                 SELECT version_id, plz, kcid, bcid
-                FROM {TARGET_SCHEMA}.transformer_classified
+                FROM transformer_classified
                 WHERE kmeans_clusters = 0
                 GROUP BY version_id, plz, kcid, bcid
             ) tc

--- a/classification/utils/get_average_values_clustering_parameters.py
+++ b/classification/utils/get_average_values_clustering_parameters.py
@@ -44,12 +44,12 @@ def get_clustering_parameters_for_kmeans_cluster_0() -> pd.DataFrame:
 
     try:
         # Run the query
-        query = """
+        query = f"""
             SELECT cp.*
-            FROM public.clustering_parameters cp
+            FROM {TARGET_SCHEMA}.clustering_parameters cp
             JOIN (
                 SELECT version_id, plz, kcid, bcid
-                FROM public.transformer_classified
+                FROM {TARGET_SCHEMA}.transformer_classified
                 WHERE kmeans_clusters = 0
                 GROUP BY version_id, plz, kcid, bcid
             ) tc

--- a/pylovo/GridGenerator.py
+++ b/pylovo/GridGenerator.py
@@ -1,5 +1,6 @@
 import warnings
 from pathlib import Path
+import traceback
 
 import pandapower as pp
 import numpy as np
@@ -436,12 +437,13 @@ class GridGenerator:
             print('Grids for this PLZ have already been generated.')
         except Exception as e:
             self.logger.error(f"Error during grid generation for PLZ {self.plz}: {e}")
+            traceback.print_exc()
             self.logger.info(f"Skipped PLZ {self.plz} due to generation error.")
             self.pgr.conn.rollback()  # rollback the transaction
             self.pgr.delete_plz_from_sample_set_table(str(CLASSIFICATION_VERSION), self.plz)  # delete from sample set
             return
 
-        self.pgr.drop_temp_tables()  # drop temp tables
+        #self.pgr.drop_temp_tables()  # drop temp tables
         self.pgr.commit_changes()    # commit the changes to the database
 
         print('-------------------- end', self.plz, '-----------------------------')

--- a/pylovo/GridGenerator.py
+++ b/pylovo/GridGenerator.py
@@ -443,7 +443,7 @@ class GridGenerator:
             self.pgr.delete_plz_from_sample_set_table(str(CLASSIFICATION_VERSION), self.plz)  # delete from sample set
             return
 
-        #self.pgr.drop_temp_tables()  # drop temp tables
+        self.pgr.drop_temp_tables()  # drop temp tables
         self.pgr.commit_changes()    # commit the changes to the database
 
         print('-------------------- end', self.plz, '-----------------------------')

--- a/pylovo/GridGenerator.py
+++ b/pylovo/GridGenerator.py
@@ -1,6 +1,5 @@
 import warnings
 from pathlib import Path
-import traceback
 
 import pandapower as pp
 import numpy as np
@@ -437,7 +436,6 @@ class GridGenerator:
             print('Grids for this PLZ have already been generated.')
         except Exception as e:
             self.logger.error(f"Error during grid generation for PLZ {self.plz}: {e}")
-            traceback.print_exc()
             self.logger.info(f"Skipped PLZ {self.plz} due to generation error.")
             self.pgr.conn.rollback()  # rollback the transaction
             self.pgr.delete_plz_from_sample_set_table(str(CLASSIFICATION_VERSION), self.plz)  # delete from sample set

--- a/pylovo/SyngridDatabaseConstructor.py
+++ b/pylovo/SyngridDatabaseConstructor.py
@@ -316,6 +316,8 @@ class SyngridDatabaseConstructor:
         cur = self.pgr.conn.cursor()
         sc_path = os.path.join(os.getcwd(), "pylovo", "dump_functions.sql")
         with open(sc_path, 'r') as sc_file:
-            print("Executing dump_functions.sql script.")
-            cur.execute(sc_file.read())
+            print(f"Executing dump_functions.sql script with schema '{TARGET_SCHEMA}'.")
+            sql = sc_file.read()
+            rendered_sql = sql.replace('{schema}', TARGET_SCHEMA)
+            cur.execute(rendered_sql)
             self.pgr.conn.commit()

--- a/pylovo/SyngridDatabaseConstructor.py
+++ b/pylovo/SyngridDatabaseConstructor.py
@@ -318,6 +318,5 @@ class SyngridDatabaseConstructor:
         with open(sc_path, 'r') as sc_file:
             print(f"Executing dump_functions.sql script with schema '{TARGET_SCHEMA}'.")
             sql = sc_file.read()
-            rendered_sql = sql.replace('{schema}', TARGET_SCHEMA)
-            cur.execute(rendered_sql)
+            cur.execute(sql)
             self.pgr.conn.commit()

--- a/pylovo/SyngridDatabaseConstructor.py
+++ b/pylovo/SyngridDatabaseConstructor.py
@@ -37,7 +37,7 @@ class SyngridDatabaseConstructor:
         with self.pgr.conn.cursor() as cur:
             cur.execute(
                 """SELECT table_name FROM information_schema.tables
-                   WHERE table_schema = 'public'"""
+                   WHERE table_schema = %s""", (TARGET_SCHEMA,)
             )
             table_name_list = [tup[0] for tup in cur.fetchall()]
 
@@ -199,7 +199,7 @@ class SyngridDatabaseConstructor:
                 con=self.pgr.sqla_engine,
                 if_exists="append",
                 index=False,
-                schema="public",
+                schema=TARGET_SCHEMA,
             )
 
             et = time.time()

--- a/pylovo/SyngridDatabaseConstructor.py
+++ b/pylovo/SyngridDatabaseConstructor.py
@@ -108,7 +108,7 @@ class SyngridDatabaseConstructor:
                     f"PG:dbname={DBNAME} user={USER} password={PASSWORD} host={HOST} port={PORT}",
                     file_path,
                     "-nln",
-                    table_name,
+                    f"{TARGET_SCHEMA}.{table_name}",  # explicitly tells ogr2ogr where to append (for the case of table already existing)
                     "-nlt",
                     # "MULTIPOLYGON",
                     "PROMOTE_TO_MULTI",
@@ -116,6 +116,7 @@ class SyngridDatabaseConstructor:
                     "EPSG:3035",
                     "-lco",
                     "geometry_name=geom",
+                    "-lco", f"SCHEMA={TARGET_SCHEMA}", # ensures creation happens in correct schema
             ]
             if skip_failures:
                 command.append("-skipfailures")

--- a/pylovo/SyngridDatabaseConstructor.py
+++ b/pylovo/SyngridDatabaseConstructor.py
@@ -200,7 +200,6 @@ class SyngridDatabaseConstructor:
                 con=self.pgr.sqla_engine,
                 if_exists="append",
                 index=False,
-                schema=TARGET_SCHEMA,
             )
 
             et = time.time()

--- a/pylovo/config_data.yaml
+++ b/pylovo/config_data.yaml
@@ -5,6 +5,9 @@ HOST: localhost
 PORT: 5432
 PASSWORD: postgres
 
+# Schema selection for database writes/reads
+TARGET_SCHEMA: public
+
 # Toggles whether the grid json files will be saved in a folder or just in the db
 SAVE_GRID_FOLDER: False
 

--- a/pylovo/config_loader.py
+++ b/pylovo/config_loader.py
@@ -26,6 +26,7 @@ USER = os.getenv("USER", CONFIG_DATA["USER"])
 HOST = os.getenv("HOST", CONFIG_DATA["HOST"])
 PORT = os.getenv("PORT", CONFIG_DATA["PORT"])
 PASSWORD = os.getenv("PASSWORD", CONFIG_DATA["PASSWORD"])
+TARGET_SCHEMA = os.getenv("TARGET_SCHEMA", CONFIG_DATA["TARGET_SCHEMA"])
 
 # Assign other variables from CONFIG_DATA
 RESULT_DIR = os.path.join(os.getcwd(), "results")

--- a/pylovo/config_table_structure.py
+++ b/pylovo/config_table_structure.py
@@ -80,11 +80,9 @@ CREATE_QUERIES = {
         CONSTRAINT fk_postcode_result_version_id
             FOREIGN KEY (version_id)
             REFERENCES version (version_id)
-            REFERENCES version (version_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_postcode_result_plz
             FOREIGN KEY (postcode_result_plz)
-            REFERENCES postcode (plz)
             REFERENCES postcode (plz)
             ON DELETE CASCADE
     )
@@ -106,11 +104,9 @@ CREATE_QUERIES = {
         CONSTRAINT fk_grid_result_version_id_plz
             FOREIGN KEY (version_id, plz)
             REFERENCES postcode_result (version_id, postcode_result_plz)
-            REFERENCES postcode_result (version_id, postcode_result_plz)
             ON DELETE CASCADE
     );
     CREATE INDEX idx_grid_result_version_id_plz_bcid_kcid
-    ON grid_result (version_id, plz, bcid, kcid)
     ON grid_result (version_id, plz, bcid, kcid)
     """,
     "lines_result": """
@@ -125,7 +121,6 @@ CREATE_QUERIES = {
         length_km numeric,
         CONSTRAINT fk_lines_result_grid_result
             FOREIGN KEY (grid_result_id)
-            REFERENCES grid_result (grid_result_id)
             REFERENCES grid_result (grid_result_id)
             ON DELETE CASCADE
     )
@@ -159,16 +154,13 @@ CREATE_QUERIES = {
         CONSTRAINT fk_buildings_result_grid_result
             FOREIGN KEY (version_id, grid_result_id)
             REFERENCES grid_result (version_id, grid_result_id)
-            REFERENCES grid_result (version_id, grid_result_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_buildings_result_type
             FOREIGN KEY (type)
             REFERENCES consumer_categories (definition)
-            REFERENCES consumer_categories (definition)
             ON DELETE CASCADE
     );
     CREATE INDEX idx_buildings_result_grid_result_id
-    ON buildings_result (grid_result_id);
     ON buildings_result (grid_result_id);
     """,
     "municipal_register": """CREATE TABLE IF NOT EXISTS municipal_register (
@@ -199,11 +191,9 @@ CREATE_QUERIES = {
         CONSTRAINT fk_sample_set_classification_id
             FOREIGN KEY (classification_id)
             REFERENCES classification_version (classification_id)
-            REFERENCES classification_version (classification_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_sample_set_plz
             FOREIGN KEY (plz, ags)
-            REFERENCES municipal_register (plz, ags)
             REFERENCES municipal_register (plz, ags)
             ON DELETE CASCADE
     )
@@ -244,7 +234,6 @@ CREATE_QUERIES = {
         CONSTRAINT fk_clustering_parameters_grid_result
             FOREIGN KEY (grid_result_id)
             REFERENCES grid_result (grid_result_id)
-            REFERENCES grid_result (grid_result_id)
             ON DELETE CASCADE
     )
     """,
@@ -266,11 +255,9 @@ CREATE_QUERIES = {
         CONSTRAINT fk_tp_grid_result_id
             FOREIGN KEY (grid_result_id)
             REFERENCES grid_result (grid_result_id)
-            REFERENCES grid_result (grid_result_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_tp_osm_id
             FOREIGN KEY (osm_id)
-            REFERENCES transformers (osm_id)
             REFERENCES transformers (osm_id)
     )
     """,
@@ -289,11 +276,9 @@ CREATE_QUERIES = {
         CONSTRAINT fk_transformer_classified_classification_id
             FOREIGN KEY (classification_id)
             REFERENCES classification_version (classification_id)
-            REFERENCES classification_version (classification_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_transformer_classified_grid_result
             FOREIGN KEY (grid_result_id)
-            REFERENCES grid_result (grid_result_id)
             REFERENCES grid_result (grid_result_id)
             ON DELETE CASCADE
     )
@@ -329,7 +314,6 @@ CREATE_QUERIES = {
         CONSTRAINT fk_ways_result_version_id_plz
             FOREIGN KEY (version_id, plz)
             REFERENCES postcode_result (version_id, postcode_result_plz)
-            REFERENCES postcode_result (version_id, postcode_result_plz)
             ON DELETE CASCADE
     )
     """,
@@ -350,7 +334,6 @@ CREATE_QUERIES = {
         CONSTRAINT fk_plz_parameters_version_id_plz
             FOREIGN KEY (version_id, plz)
             REFERENCES postcode_result (version_id, postcode_result_plz)
-            REFERENCES postcode_result (version_id, postcode_result_plz)
             ON DELETE CASCADE
     )
     """,
@@ -359,15 +342,11 @@ CREATE_QUERIES = {
         SELECT tp.*, gr.version_id, gr.kcid, gr.bcid, gr.plz
         FROM transformer_positions tp
         JOIN grid_result gr ON tp.grid_result_id = gr.grid_result_id
-        FROM transformer_positions tp
-        JOIN grid_result gr ON tp.grid_result_id = gr.grid_result_id
     )
     """,
     "transformer_classified_with_grid": """
     CREATE OR REPLACE VIEW transformer_classified_with_grid AS (
         SELECT tc.*, gr.version_id, gr.kcid, gr.bcid, gr.plz
-        FROM transformer_classified tc
-        JOIN grid_result gr ON tc.grid_result_id = gr.grid_result_id
         FROM transformer_classified tc
         JOIN grid_result gr ON tc.grid_result_id = gr.grid_result_id
     )
@@ -378,8 +357,6 @@ CREATE_QUERIES = {
             (br.version_id || '_' || br.osm_id) AS id,
             br.*,
             gr.kcid, gr.bcid, gr.plz
-        FROM buildings_result br
-        JOIN grid_result gr ON br.grid_result_id = gr.grid_result_id
         FROM buildings_result br
         JOIN grid_result gr ON br.grid_result_id = gr.grid_result_id
     )
@@ -396,8 +373,6 @@ CREATE_QUERIES = {
             lr.to_bus,
             lr.length_km,
             gr.version_id, gr.kcid, gr.bcid, gr.plz
-        FROM lines_result lr
-        JOIN grid_result gr ON lr.grid_result_id = gr.grid_result_id
         FROM lines_result lr
         JOIN grid_result gr ON lr.grid_result_id = gr.grid_result_id
     )

--- a/pylovo/config_table_structure.py
+++ b/pylovo/config_table_structure.py
@@ -1,6 +1,6 @@
 # Database schema - table structure
 CREATE_QUERIES = {
-    "res": f"""CREATE TABLE IF NOT EXISTS res (
+    "res": """CREATE TABLE IF NOT EXISTS res (
         osm_id varchar PRIMARY KEY,
         area numeric(23, 15),
         use varchar(80),
@@ -17,7 +17,7 @@ CREATE_QUERIES = {
         geom geometry(MultiPolygon,3035)
     )
     """,
-    "oth": f"""CREATE TABLE IF NOT EXISTS oth (
+    "oth": """CREATE TABLE IF NOT EXISTS oth (
         osm_id varchar PRIMARY KEY,
         area numeric(23, 15),
         use varchar(80),
@@ -26,7 +26,7 @@ CREATE_QUERIES = {
         geom geometry(MultiPolygon,3035)
     )
     """,
-    "equipment_data": f"""
+    "equipment_data": """
     CREATE TABLE IF NOT EXISTS equipment_data (
         name varchar(100) PRIMARY KEY,
         s_max_kva integer,
@@ -39,7 +39,7 @@ CREATE_QUERIES = {
         application_area integer
     )
     """,
-    "version": f"""CREATE TABLE IF NOT EXISTS version (
+    "version": """CREATE TABLE IF NOT EXISTS version (
         version_id varchar(10) PRIMARY KEY,
         version_comment varchar, 
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -49,7 +49,7 @@ CREATE_QUERIES = {
         other_parameters varchar
     )
     """,
-    "classification_version": f"""
+    "classification_version": """
     CREATE TABLE IF NOT EXISTS classification_version (
         classification_id integer NOT NULL,
         classification_version_comment varchar, 
@@ -58,7 +58,7 @@ CREATE_QUERIES = {
         CONSTRAINT classification_pkey PRIMARY KEY (classification_id)
     )
     """,
-    "postcode": f"""
+    "postcode": """
     CREATE TABLE IF NOT EXISTS postcode (
         postcode_id integer NOT NULL,
         plz int UNIQUE NOT NULL,
@@ -69,7 +69,7 @@ CREATE_QUERIES = {
         CONSTRAINT "plz-5stellig_pkey" PRIMARY KEY (postcode_id)
     )
     """,
-    "postcode_result": f"""
+    "postcode_result": """
     CREATE TABLE IF NOT EXISTS postcode_result (   
         version_id varchar(10) NOT NULL,
         postcode_result_plz integer NOT NULL,
@@ -80,15 +80,17 @@ CREATE_QUERIES = {
         CONSTRAINT fk_postcode_result_version_id
             FOREIGN KEY (version_id)
             REFERENCES version (version_id)
+            REFERENCES version (version_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_postcode_result_plz
             FOREIGN KEY (postcode_result_plz)
+            REFERENCES postcode (plz)
             REFERENCES postcode (plz)
             ON DELETE CASCADE
     )
     """,
     # old name: building_clusters, got merged with grids
-    "grid_result": f"""
+    "grid_result": """
     CREATE TABLE IF NOT EXISTS grid_result (
         grid_result_id SERIAL PRIMARY KEY,
         version_id varchar(10) NOT NULL,
@@ -104,12 +106,14 @@ CREATE_QUERIES = {
         CONSTRAINT fk_grid_result_version_id_plz
             FOREIGN KEY (version_id, plz)
             REFERENCES postcode_result (version_id, postcode_result_plz)
+            REFERENCES postcode_result (version_id, postcode_result_plz)
             ON DELETE CASCADE
     );
     CREATE INDEX idx_grid_result_version_id_plz_bcid_kcid
     ON grid_result (version_id, plz, bcid, kcid)
+    ON grid_result (version_id, plz, bcid, kcid)
     """,
-    "lines_result": f"""
+    "lines_result": """
     CREATE TABLE IF NOT EXISTS lines_result (
         lines_result_id SERIAL PRIMARY KEY,
         grid_result_id bigint NOT NULL,
@@ -122,10 +126,11 @@ CREATE_QUERIES = {
         CONSTRAINT fk_lines_result_grid_result
             FOREIGN KEY (grid_result_id)
             REFERENCES grid_result (grid_result_id)
+            REFERENCES grid_result (grid_result_id)
             ON DELETE CASCADE
     )
     """,
-    "consumer_categories": f"""
+    "consumer_categories": """
     CREATE TABLE IF NOT EXISTS consumer_categories (
         consumer_category_id integer PRIMARY KEY,
         definition varchar(30) UNIQUE NOT NULL,
@@ -136,7 +141,7 @@ CREATE_QUERIES = {
         sim_factor numeric(10,2) NOT NULL
     )
     """,
-    "buildings_result": f"""
+    "buildings_result": """
     CREATE TABLE IF NOT EXISTS buildings_result (
         version_id varchar(10) NOT NULL,
         osm_id varchar NOT NULL,
@@ -154,16 +159,19 @@ CREATE_QUERIES = {
         CONSTRAINT fk_buildings_result_grid_result
             FOREIGN KEY (version_id, grid_result_id)
             REFERENCES grid_result (version_id, grid_result_id)
+            REFERENCES grid_result (version_id, grid_result_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_buildings_result_type
             FOREIGN KEY (type)
+            REFERENCES consumer_categories (definition)
             REFERENCES consumer_categories (definition)
             ON DELETE CASCADE
     );
     CREATE INDEX idx_buildings_result_grid_result_id
     ON buildings_result (grid_result_id);
+    ON buildings_result (grid_result_id);
     """,
-    "municipal_register": f"""CREATE TABLE IF NOT EXISTS municipal_register (
+    "municipal_register": """CREATE TABLE IF NOT EXISTS municipal_register (
         plz integer,
         pop bigint,
         area double precision,
@@ -178,7 +186,7 @@ CREATE_QUERIES = {
         CONSTRAINT municipal_register_pkey PRIMARY KEY (plz, ags)
     )
     """,
-    "sample_set": f"""CREATE TABLE IF NOT EXISTS sample_set (
+    "sample_set": """CREATE TABLE IF NOT EXISTS sample_set (
         classification_id integer NOT NULL,
         plz integer NOT NULL,
         ags bigint,
@@ -191,14 +199,16 @@ CREATE_QUERIES = {
         CONSTRAINT fk_sample_set_classification_id
             FOREIGN KEY (classification_id)
             REFERENCES classification_version (classification_id)
+            REFERENCES classification_version (classification_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_sample_set_plz
             FOREIGN KEY (plz, ags)
             REFERENCES municipal_register (plz, ags)
+            REFERENCES municipal_register (plz, ags)
             ON DELETE CASCADE
     )
     """,
-    "clustering_parameters": f"""CREATE TABLE IF NOT EXISTS clustering_parameters (
+    "clustering_parameters": """CREATE TABLE IF NOT EXISTS clustering_parameters (
         grid_result_id bigint PRIMARY KEY,
         
         no_connection_buses integer,
@@ -234,10 +244,11 @@ CREATE_QUERIES = {
         CONSTRAINT fk_clustering_parameters_grid_result
             FOREIGN KEY (grid_result_id)
             REFERENCES grid_result (grid_result_id)
+            REFERENCES grid_result (grid_result_id)
             ON DELETE CASCADE
     )
     """,
-    "transformers": f"""CREATE TABLE IF NOT EXISTS transformers (
+    "transformers": """CREATE TABLE IF NOT EXISTS transformers (
         osm_id varchar PRIMARY KEY,
         area double precision,
         power varchar,
@@ -246,7 +257,7 @@ CREATE_QUERIES = {
         geom geometry(MultiPoint, 3035)
     )
     """,
-    "transformer_positions": f"""
+    "transformer_positions": """
     CREATE TABLE IF NOT EXISTS transformer_positions (
         grid_result_id bigint PRIMARY KEY,
         geom geometry(Point,3035),
@@ -255,13 +266,15 @@ CREATE_QUERIES = {
         CONSTRAINT fk_tp_grid_result_id
             FOREIGN KEY (grid_result_id)
             REFERENCES grid_result (grid_result_id)
+            REFERENCES grid_result (grid_result_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_tp_osm_id
             FOREIGN KEY (osm_id)
             REFERENCES transformers (osm_id)
+            REFERENCES transformers (osm_id)
     )
     """,
-    "transformer_classified": f"""
+    "transformer_classified": """
     CREATE TABLE IF NOT EXISTS transformer_classified (
         grid_result_id bigint NOT NULL,
         geom geometry(Point,3035),
@@ -276,19 +289,21 @@ CREATE_QUERIES = {
         CONSTRAINT fk_transformer_classified_classification_id
             FOREIGN KEY (classification_id)
             REFERENCES classification_version (classification_id)
+            REFERENCES classification_version (classification_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_transformer_classified_grid_result
             FOREIGN KEY (grid_result_id)
             REFERENCES grid_result (grid_result_id)
+            REFERENCES grid_result (grid_result_id)
             ON DELETE CASCADE
     )
     """,
-    "ags_log": f"""
+    "ags_log": """
     CREATE TABLE IF NOT EXISTS ags_log (
         ags bigint PRIMARY KEY
     )
     """,
-    "ways": f"""
+    "ways": """
     CREATE TABLE IF NOT EXISTS ways (
         clazz integer,
         source integer,
@@ -299,7 +314,7 @@ CREATE_QUERIES = {
         way_id integer PRIMARY KEY
     )
     """,
-    "ways_result": f"""
+    "ways_result": """
     CREATE TABLE IF NOT EXISTS ways_result (
         version_id varchar(10) NOT NULL,
         clazz integer,
@@ -314,12 +329,13 @@ CREATE_QUERIES = {
         CONSTRAINT fk_ways_result_version_id_plz
             FOREIGN KEY (version_id, plz)
             REFERENCES postcode_result (version_id, postcode_result_plz)
+            REFERENCES postcode_result (version_id, postcode_result_plz)
             ON DELETE CASCADE
     )
     """,
     # old name: grid_parameters
     # saves grid parameters for a whole plz for visualization
-    "plz_parameters": f"""
+    "plz_parameters": """
     CREATE TABLE IF NOT EXISTS plz_parameters (
         version_id varchar(10) NOT NULL,
         plz integer NOT NULL,
@@ -334,24 +350,29 @@ CREATE_QUERIES = {
         CONSTRAINT fk_plz_parameters_version_id_plz
             FOREIGN KEY (version_id, plz)
             REFERENCES postcode_result (version_id, postcode_result_plz)
+            REFERENCES postcode_result (version_id, postcode_result_plz)
             ON DELETE CASCADE
     )
     """,
-    "transformer_positions_with_grid": f"""
+    "transformer_positions_with_grid": """
     CREATE OR REPLACE VIEW transformer_positions_with_grid AS (
         SELECT tp.*, gr.version_id, gr.kcid, gr.bcid, gr.plz
         FROM transformer_positions tp
         JOIN grid_result gr ON tp.grid_result_id = gr.grid_result_id
+        FROM transformer_positions tp
+        JOIN grid_result gr ON tp.grid_result_id = gr.grid_result_id
     )
     """,
-    "transformer_classified_with_grid": f"""
+    "transformer_classified_with_grid": """
     CREATE OR REPLACE VIEW transformer_classified_with_grid AS (
         SELECT tc.*, gr.version_id, gr.kcid, gr.bcid, gr.plz
         FROM transformer_classified tc
         JOIN grid_result gr ON tc.grid_result_id = gr.grid_result_id
+        FROM transformer_classified tc
+        JOIN grid_result gr ON tc.grid_result_id = gr.grid_result_id
     )
     """,
-    "buildings_result_with_grid": f"""
+    "buildings_result_with_grid": """
     CREATE OR REPLACE VIEW buildings_result_with_grid AS (
         SELECT
             (br.version_id || '_' || br.osm_id) AS id,
@@ -359,9 +380,11 @@ CREATE_QUERIES = {
             gr.kcid, gr.bcid, gr.plz
         FROM buildings_result br
         JOIN grid_result gr ON br.grid_result_id = gr.grid_result_id
+        FROM buildings_result br
+        JOIN grid_result gr ON br.grid_result_id = gr.grid_result_id
     )
     """,
-    "lines_result_with_grid": f"""
+    "lines_result_with_grid": """
     CREATE OR REPLACE VIEW lines_result_with_grid AS (
         SELECT
             lr.lines_result_id as id,
@@ -375,12 +398,14 @@ CREATE_QUERIES = {
             gr.version_id, gr.kcid, gr.bcid, gr.plz
         FROM lines_result lr
         JOIN grid_result gr ON lr.grid_result_id = gr.grid_result_id
+        FROM lines_result lr
+        JOIN grid_result gr ON lr.grid_result_id = gr.grid_result_id
     )
     """
 }
 
 TEMP_CREATE_QUERIES = {
-    "buildings_tem": f"""CREATE TABLE IF NOT EXISTS buildings_tem
+    "buildings_tem": """CREATE TABLE IF NOT EXISTS buildings_tem
     (
         osm_id varchar,
         area numeric,
@@ -396,7 +421,7 @@ TEMP_CREATE_QUERIES = {
         floors integer,
         connection_point integer
     )""",
-    "ways_tem": f"""CREATE TABLE IF NOT EXISTS ways_tem
+    "ways_tem": """CREATE TABLE IF NOT EXISTS ways_tem
     (
         clazz integer,
         source integer,

--- a/pylovo/config_table_structure.py
+++ b/pylovo/config_table_structure.py
@@ -1,6 +1,6 @@
 # Database schema - table structure
 CREATE_QUERIES = {
-    "res": """CREATE TABLE IF NOT EXISTS public.res (
+    "res": f"""CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.res (
         osm_id varchar PRIMARY KEY,
         area numeric(23, 15),
         use varchar(80),
@@ -17,7 +17,7 @@ CREATE_QUERIES = {
         geom geometry(MultiPolygon,3035)
     )
     """,
-    "oth": """CREATE TABLE IF NOT EXISTS public.oth (
+    "oth": f"""CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.oth (
         osm_id varchar PRIMARY KEY,
         area numeric(23, 15),
         use varchar(80),
@@ -26,8 +26,8 @@ CREATE_QUERIES = {
         geom geometry(MultiPolygon,3035)
     )
     """,
-    "equipment_data": """
-    CREATE TABLE IF NOT EXISTS public.equipment_data (
+    "equipment_data": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.equipment_data (
         name varchar(100) PRIMARY KEY,
         s_max_kva integer,
         max_i_a integer,
@@ -39,7 +39,7 @@ CREATE_QUERIES = {
         application_area integer
     )
     """,
-    "version": """CREATE TABLE IF NOT EXISTS public.version (
+    "version": f"""CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.version (
         version_id varchar(10) PRIMARY KEY,
         version_comment varchar, 
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -49,8 +49,8 @@ CREATE_QUERIES = {
         other_parameters varchar
     )
     """,
-    "classification_version": """
-    CREATE TABLE IF NOT EXISTS public.classification_version (
+    "classification_version": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.classification_version (
         classification_id integer NOT NULL,
         classification_version_comment varchar, 
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -58,8 +58,8 @@ CREATE_QUERIES = {
         CONSTRAINT classification_pkey PRIMARY KEY (classification_id)
     )
     """,
-    "postcode": """
-    CREATE TABLE IF NOT EXISTS public.postcode (
+    "postcode": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.postcode (
         postcode_id integer NOT NULL,
         plz int UNIQUE NOT NULL,
         note varchar,
@@ -69,8 +69,8 @@ CREATE_QUERIES = {
         CONSTRAINT "plz-5stellig_pkey" PRIMARY KEY (postcode_id)
     )
     """,
-    "postcode_result": """
-    CREATE TABLE IF NOT EXISTS public.postcode_result (   
+    "postcode_result": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.postcode_result (   
         version_id varchar(10) NOT NULL,
         postcode_result_plz integer NOT NULL,
         settlement_type integer,
@@ -79,17 +79,17 @@ CREATE_QUERIES = {
         CONSTRAINT "postcode_result_pkey" PRIMARY KEY (version_id, postcode_result_plz),
         CONSTRAINT fk_postcode_result_version_id
             FOREIGN KEY (version_id)
-            REFERENCES public.version (version_id)
+            REFERENCES {TARGET_SCHEMA}.version (version_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_postcode_result_plz
             FOREIGN KEY (postcode_result_plz)
-            REFERENCES public.postcode (plz)
+            REFERENCES {TARGET_SCHEMA}.postcode (plz)
             ON DELETE CASCADE
     )
     """,
     # old name: building_clusters, got merged with grids
-    "grid_result": """
-    CREATE TABLE IF NOT EXISTS public.grid_result (
+    "grid_result": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.grid_result (
         grid_result_id SERIAL PRIMARY KEY,
         version_id varchar(10) NOT NULL,
         kcid integer NOT NULL,
@@ -103,14 +103,14 @@ CREATE_QUERIES = {
         CONSTRAINT unique_grid_result_id_version_id UNIQUE (version_id, grid_result_id),
         CONSTRAINT fk_grid_result_version_id_plz
             FOREIGN KEY (version_id, plz)
-            REFERENCES public.postcode_result (version_id, postcode_result_plz)
+            REFERENCES {TARGET_SCHEMA}.postcode_result (version_id, postcode_result_plz)
             ON DELETE CASCADE
     );
     CREATE INDEX idx_grid_result_version_id_plz_bcid_kcid
-    ON public.grid_result (version_id, plz, bcid, kcid)
+    ON {TARGET_SCHEMA}.grid_result (version_id, plz, bcid, kcid)
     """,
-    "lines_result": """
-    CREATE TABLE IF NOT EXISTS public.lines_result (
+    "lines_result": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.lines_result (
         lines_result_id SERIAL PRIMARY KEY,
         grid_result_id bigint NOT NULL,
         geom geometry(LineString,3035),
@@ -121,12 +121,12 @@ CREATE_QUERIES = {
         length_km numeric,
         CONSTRAINT fk_lines_result_grid_result
             FOREIGN KEY (grid_result_id)
-            REFERENCES public.grid_result (grid_result_id)
+            REFERENCES {TARGET_SCHEMA}.grid_result (grid_result_id)
             ON DELETE CASCADE
     )
     """,
-    "consumer_categories": """
-    CREATE TABLE IF NOT EXISTS public.consumer_categories (
+    "consumer_categories": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.consumer_categories (
         consumer_category_id integer PRIMARY KEY,
         definition varchar(30) UNIQUE NOT NULL,
         peak_load numeric(10,2),
@@ -136,8 +136,8 @@ CREATE_QUERIES = {
         sim_factor numeric(10,2) NOT NULL
     )
     """,
-    "buildings_result": """
-    CREATE TABLE IF NOT EXISTS public.buildings_result (
+    "buildings_result": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.buildings_result (
         version_id varchar(10) NOT NULL,
         osm_id varchar NOT NULL,
         grid_result_id bigint NOT NULL,
@@ -153,17 +153,17 @@ CREATE_QUERIES = {
         CONSTRAINT buildings_result_pkey PRIMARY KEY (version_id, osm_id),
         CONSTRAINT fk_buildings_result_grid_result
             FOREIGN KEY (version_id, grid_result_id)
-            REFERENCES public.grid_result (version_id, grid_result_id)
+            REFERENCES {TARGET_SCHEMA}.grid_result (version_id, grid_result_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_buildings_result_type
             FOREIGN KEY (type)
-            REFERENCES public.consumer_categories (definition)
+            REFERENCES {TARGET_SCHEMA}.consumer_categories (definition)
             ON DELETE CASCADE
     );
     CREATE INDEX idx_buildings_result_grid_result_id
-    ON public.buildings_result (grid_result_id);
+    ON {TARGET_SCHEMA}.buildings_result (grid_result_id);
     """,
-    "municipal_register": """CREATE TABLE IF NOT EXISTS public.municipal_register (
+    "municipal_register": f"""CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.municipal_register (
         plz integer,
         pop bigint,
         area double precision,
@@ -178,7 +178,7 @@ CREATE_QUERIES = {
         CONSTRAINT municipal_register_pkey PRIMARY KEY (plz, ags)
     )
     """,
-    "sample_set": """CREATE TABLE IF NOT EXISTS public.sample_set (
+    "sample_set": f"""CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.sample_set (
         classification_id integer NOT NULL,
         plz integer NOT NULL,
         ags bigint,
@@ -190,15 +190,15 @@ CREATE_QUERIES = {
         CONSTRAINT sample_set_pkey PRIMARY KEY (classification_id, plz),
         CONSTRAINT fk_sample_set_classification_id
             FOREIGN KEY (classification_id)
-            REFERENCES public.classification_version (classification_id)
+            REFERENCES {TARGET_SCHEMA}.classification_version (classification_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_sample_set_plz
             FOREIGN KEY (plz, ags)
-            REFERENCES public.municipal_register (plz, ags)
+            REFERENCES {TARGET_SCHEMA}.municipal_register (plz, ags)
             ON DELETE CASCADE
     )
     """,
-    "clustering_parameters": """CREATE TABLE IF NOT EXISTS public.clustering_parameters (
+    "clustering_parameters": f"""CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.clustering_parameters (
         grid_result_id bigint PRIMARY KEY,
         
         no_connection_buses integer,
@@ -233,11 +233,11 @@ CREATE_QUERIES = {
         filtered boolean,
         CONSTRAINT fk_clustering_parameters_grid_result
             FOREIGN KEY (grid_result_id)
-            REFERENCES public.grid_result (grid_result_id)
+            REFERENCES {TARGET_SCHEMA}.grid_result (grid_result_id)
             ON DELETE CASCADE
     )
     """,
-    "transformers": """CREATE TABLE IF NOT EXISTS public.transformers (
+    "transformers": f"""CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.transformers (
         osm_id varchar PRIMARY KEY,
         area double precision,
         power varchar,
@@ -246,23 +246,23 @@ CREATE_QUERIES = {
         geom geometry(MultiPoint, 3035)
     )
     """,
-    "transformer_positions": """
-    CREATE TABLE IF NOT EXISTS public.transformer_positions (
+    "transformer_positions": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.transformer_positions (
         grid_result_id bigint PRIMARY KEY,
         geom geometry(Point,3035),
         osm_id varchar UNIQUE,
         "comment" varchar,
         CONSTRAINT fk_tp_grid_result_id
             FOREIGN KEY (grid_result_id)
-            REFERENCES public.grid_result (grid_result_id)
+            REFERENCES {TARGET_SCHEMA}.grid_result (grid_result_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_tp_osm_id
             FOREIGN KEY (osm_id)
-            REFERENCES public.transformers (osm_id)
+            REFERENCES {TARGET_SCHEMA}.transformers (osm_id)
     )
     """,
-    "transformer_classified": """
-    CREATE TABLE IF NOT EXISTS public.transformer_classified (
+    "transformer_classified": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.transformer_classified (
         grid_result_id bigint NOT NULL,
         geom geometry(Point,3035),
         kmedoid_clusters integer,
@@ -275,21 +275,21 @@ CREATE_QUERIES = {
         CONSTRAINT pk_grid_result_id PRIMARY KEY (grid_result_id, classification_id),
         CONSTRAINT fk_transformer_classified_classification_id
             FOREIGN KEY (classification_id)
-            REFERENCES public.classification_version (classification_id)
+            REFERENCES {TARGET_SCHEMA}.classification_version (classification_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_transformer_classified_grid_result
             FOREIGN KEY (grid_result_id)
-            REFERENCES public.grid_result (grid_result_id)
+            REFERENCES {TARGET_SCHEMA}.grid_result (grid_result_id)
             ON DELETE CASCADE
     )
     """,
-    "ags_log": """
-    CREATE TABLE IF NOT EXISTS public.ags_log (
+    "ags_log": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.ags_log (
         ags bigint PRIMARY KEY
     )
     """,
-    "ways": """
-    CREATE TABLE IF NOT EXISTS public.ways (
+    "ways": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.ways (
         clazz integer,
         source integer,
         target integer,
@@ -299,8 +299,8 @@ CREATE_QUERIES = {
         way_id integer PRIMARY KEY
     )
     """,
-    "ways_result": """
-    CREATE TABLE IF NOT EXISTS public.ways_result (
+    "ways_result": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.ways_result (
         version_id varchar(10) NOT NULL,
         clazz integer,
         source integer,
@@ -313,14 +313,14 @@ CREATE_QUERIES = {
         CONSTRAINT pk_ways_result PRIMARY KEY (version_id, way_id, plz),
         CONSTRAINT fk_ways_result_version_id_plz
             FOREIGN KEY (version_id, plz)
-            REFERENCES public.postcode_result (version_id, postcode_result_plz)
+            REFERENCES {TARGET_SCHEMA}.postcode_result (version_id, postcode_result_plz)
             ON DELETE CASCADE
     )
     """,
     # old name: grid_parameters
     # saves grid parameters for a whole plz for visualization
-    "plz_parameters": """
-    CREATE TABLE IF NOT EXISTS public.plz_parameters (
+    "plz_parameters": f"""
+    CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.plz_parameters (
         version_id varchar(10) NOT NULL,
         plz integer NOT NULL,
         trafo_num json,
@@ -333,36 +333,36 @@ CREATE_QUERIES = {
         CONSTRAINT parameters_pkey PRIMARY KEY (version_id, plz),
         CONSTRAINT fk_plz_parameters_version_id_plz
             FOREIGN KEY (version_id, plz)
-            REFERENCES public.postcode_result (version_id, postcode_result_plz)
+            REFERENCES {TARGET_SCHEMA}.postcode_result (version_id, postcode_result_plz)
             ON DELETE CASCADE
     )
     """,
-    "transformer_positions_with_grid": """
-    CREATE OR REPLACE VIEW public.transformer_positions_with_grid AS (
+    "transformer_positions_with_grid": f"""
+    CREATE OR REPLACE VIEW {TARGET_SCHEMA}.transformer_positions_with_grid AS (
         SELECT tp.*, gr.version_id, gr.kcid, gr.bcid, gr.plz
-        FROM public.transformer_positions tp
-        JOIN public.grid_result gr ON tp.grid_result_id = gr.grid_result_id
+        FROM {TARGET_SCHEMA}.transformer_positions tp
+        JOIN {TARGET_SCHEMA}.grid_result gr ON tp.grid_result_id = gr.grid_result_id
     )
     """,
-    "transformer_classified_with_grid": """
-    CREATE OR REPLACE VIEW public.transformer_classified_with_grid AS (
+    "transformer_classified_with_grid": f"""
+    CREATE OR REPLACE VIEW {TARGET_SCHEMA}.transformer_classified_with_grid AS (
         SELECT tc.*, gr.version_id, gr.kcid, gr.bcid, gr.plz
-        FROM public.transformer_classified tc
-        JOIN public.grid_result gr ON tc.grid_result_id = gr.grid_result_id
+        FROM {TARGET_SCHEMA}.transformer_classified tc
+        JOIN {TARGET_SCHEMA}.grid_result gr ON tc.grid_result_id = gr.grid_result_id
     )
     """,
-    "buildings_result_with_grid": """
-    CREATE OR REPLACE VIEW public.buildings_result_with_grid AS (
+    "buildings_result_with_grid": f"""
+    CREATE OR REPLACE VIEW {TARGET_SCHEMA}.buildings_result_with_grid AS (
         SELECT
             (br.version_id || '_' || br.osm_id) AS id,
             br.*,
             gr.kcid, gr.bcid, gr.plz
-        FROM public.buildings_result br
-        JOIN public.grid_result gr ON br.grid_result_id = gr.grid_result_id
+        FROM {TARGET_SCHEMA}.buildings_result br
+        JOIN {TARGET_SCHEMA}.grid_result gr ON br.grid_result_id = gr.grid_result_id
     )
     """,
-    "lines_result_with_grid": """
-    CREATE OR REPLACE VIEW public.lines_result_with_grid AS (
+    "lines_result_with_grid": f"""
+    CREATE OR REPLACE VIEW {TARGET_SCHEMA}.lines_result_with_grid AS (
         SELECT
             lr.lines_result_id as id,
             lr.grid_result_id,
@@ -373,14 +373,14 @@ CREATE_QUERIES = {
             lr.to_bus,
             lr.length_km,
             gr.version_id, gr.kcid, gr.bcid, gr.plz
-        FROM public.lines_result lr
-        JOIN public.grid_result gr ON lr.grid_result_id = gr.grid_result_id
+        FROM {TARGET_SCHEMA}.lines_result lr
+        JOIN {TARGET_SCHEMA}.grid_result gr ON lr.grid_result_id = gr.grid_result_id
     )
     """
 }
 
 TEMP_CREATE_QUERIES = {
-    "buildings_tem": """CREATE TABLE IF NOT EXISTS public.buildings_tem
+    "buildings_tem": f"""CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.buildings_tem
     (
         osm_id varchar,
         area numeric,
@@ -396,7 +396,7 @@ TEMP_CREATE_QUERIES = {
         floors integer,
         connection_point integer
     )""",
-    "ways_tem": """CREATE TABLE IF NOT EXISTS public.ways_tem
+    "ways_tem": f"""CREATE TABLE IF NOT EXISTS {TARGET_SCHEMA}.ways_tem
     (
         clazz integer,
         source integer,

--- a/pylovo/dump_functions.sql
+++ b/pylovo/dump_functions.sql
@@ -2,7 +2,7 @@
 -- Name: draw_home_connections(); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION public.draw_home_connections() RETURNS void
+CREATE FUNCTION {schema}.draw_home_connections() RETURNS void
     LANGUAGE plpgsql
 AS
 $$
@@ -14,7 +14,7 @@ begin
     -- Iterating buildings
     for building in
         SELECT osm_id, center
-        FROM public.buildings_tem
+        FROM {schema}.buildings_tem
         WHERE peak_load_in_kw <> 0
         loop
             --Finde Hausanschluss -> new_line
@@ -23,7 +23,7 @@ begin
                    a.line          as geom
             INTO new_line
             FROM (SELECT ST_ShortestLine(building.center, w.geom) as line
-                  FROM public.ways_tem as w
+                  FROM {schema}.ways_tem as w
                   WHERE w.clazz != 110 -- Hausanschlüsse und alte Straßen ausgeschlossen
                     AND ST_DWithin(building.center, w.geom, 2000)
                     AND ST_Distance(building.center, w.geom) > 0.1
@@ -38,7 +38,7 @@ begin
                    ST_LineInterpolatePoint(ST_Intersection(
                                                    ST_Buffer(new_line.geom, 0.1), w.geom), 0.5) as connection_point
             INTO old_street
-            FROM public.ways_tem as w
+            FROM {schema}.ways_tem as w
             WHERE ST_DWithin(new_line.geom, w.geom, 1000)                -- begrenzen
               AND ST_Intersects(ST_Buffer(new_line.geom, 0.001), w.geom) -- Kontakt existiert
               AND w.clazz != 110
@@ -54,53 +54,53 @@ begin
             IF ST_Distance(ST_StartPoint(old_street.geom), old_street.connection_point) < 0.1 THEN
 
                 new_line.geom := ST_Makeline(building.center, ST_StartPoint(old_street.geom));
-                INSERT INTO public.ways_tem (way_id, clazz, geom)
+                INSERT INTO {schema}.ways_tem (way_id, clazz, geom)
                 SELECT Max(way_id) + 1,
                        new_line.clazz,
                        new_line.geom
-                FROM public.ways_tem;
+                FROM {schema}.ways_tem;
                 --raise notice '<0.01';
                 continue;
             ELSEIF ST_Distance(ST_EndPoint(old_street.geom), old_street.connection_point) < 0.1 THEN
 
                 new_line.geom := ST_Makeline(building.center, ST_EndPoint(old_street.geom));
-                INSERT INTO public.ways_tem (way_id, clazz, geom)
+                INSERT INTO {schema}.ways_tem (way_id, clazz, geom)
                 SELECT Max(way_id) + 1,
                        new_line.clazz,
                        new_line.geom
-                FROM public.ways_tem;
+                FROM {schema}.ways_tem;
                 --raise notice '>0.99';
                 continue;
             ELSE
-                INSERT INTO public.ways_tem (way_id, clazz, geom)
+                INSERT INTO {schema}.ways_tem (way_id, clazz, geom)
                 SELECT Max(way_id) + 1,
                        new_line.clazz,
                        new_line.geom
-                FROM public.ways_tem;
+                FROM {schema}.ways_tem;
                 --raise notice 'normal';
             END IF;
 
             --Hausanschluss schneidet die Straße
             --old_street clazz ungültig machen
             DELETE
-            FROM public.ways_tem
+            FROM {schema}.ways_tem
             WHERE way_id = old_street.way_id;
 
             -- INSERT new streets as two part of old street
             -- 	first half
-            INSERT INTO public.ways_tem (way_id, clazz, geom)
+            INSERT INTO {schema}.ways_tem (way_id, clazz, geom)
             SELECT Max(way_id) + 1, --unique id guarenteed
                    103,
                    ST_LineSubstring(old_street.geom, 0, ST_LineLocatePoint(
                            old_street.geom, old_street.connection_point))
-            FROM public.ways_tem;
+            FROM {schema}.ways_tem;
             --  second half
-            INSERT INTO public.ways_tem (way_id, clazz, geom)
+            INSERT INTO {schema}.ways_tem (way_id, clazz, geom)
             SELECT Max(way_id) + 1,
                    103,
                    ST_LineSubstring(old_street.geom, ST_LineLocatePoint(
                            old_street.geom, old_street.connection_point), 1)
-            FROM public.ways_tem;
+            FROM {schema}.ways_tem;
 
 
         end loop;
@@ -114,7 +114,7 @@ $$;
 -- Name: draw_way_connections(); Type: FUNCTION; Schema: public; Owner: postgres
 --
 
-CREATE FUNCTION public.draw_way_connections() RETURNS void
+CREATE FUNCTION {schema}.draw_way_connections() RETURNS void
     LANGUAGE PLPGSQL
 AS
 $$
@@ -126,12 +126,12 @@ begin
     -- Iterating buildings
     for way in
         SELECT geom, clazz, way_id
-        FROM public.ways_tem
+        FROM {schema}.ways_tem
         loop
             --Finde Hausanschluss -> new_line
             SELECT geom, clazz, way_id
             INTO old_street
-            FROM public.ways_tem as w
+            FROM {schema}.ways_tem as w
             WHERE ST_Intersects(ST_LineSubstring(way.geom, 0.01, 0.99), w.geom) -- begrenzen
               AND w.way_id != way.way_id
             LIMIT 1;
@@ -151,42 +151,42 @@ begin
             INTO interpolate_point;
 
             DELETE
-            FROM public.ways_tem
+            FROM {schema}.ways_tem
             WHERE way_id = old_street.way_id;
 
             -- INSERT new streets as two part of old street
             -- 	first half
-            INSERT INTO public.ways_tem (way_id, clazz, geom)
+            INSERT INTO {schema}.ways_tem (way_id, clazz, geom)
             SELECT Max(way_id) + 1, --unique id guarenteed
                    old_street.clazz,
                    ST_LineSubstring(old_street.geom, 0, ST_LineLocatePoint(
                            old_street.geom, interpolate_point.geom))
-            FROM public.ways_tem;
+            FROM {schema}.ways_tem;
             --  second half
-            INSERT INTO public.ways_tem (way_id, clazz, geom)
+            INSERT INTO {schema}.ways_tem (way_id, clazz, geom)
             SELECT Max(way_id) + 1,
                    old_street.clazz,
                    ST_LineSubstring(old_street.geom, ST_LineLocatePoint(
                            old_street.geom, interpolate_point.geom), 1)
-            FROM public.ways_tem;
+            FROM {schema}.ways_tem;
 
             DELETE
-            FROM public.ways_tem
+            FROM {schema}.ways_tem
             WHERE way_id = way.way_id;
 
-            INSERT INTO public.ways_tem (way_id, clazz, geom)
+            INSERT INTO {schema}.ways_tem (way_id, clazz, geom)
             SELECT Max(way_id) + 1, --unique id guarenteed
                    way.clazz,
                    ST_LineSubstring(way.geom, 0, ST_LineLocatePoint(
                            way.geom, interpolate_point.geom))
-            FROM public.ways_tem;
+            FROM {schema}.ways_tem;
             --  second half
-            INSERT INTO public.ways_tem (way_id, clazz, geom)
+            INSERT INTO {schema}.ways_tem (way_id, clazz, geom)
             SELECT Max(way_id) + 1,
                    way.clazz,
                    ST_LineSubstring(way.geom, ST_LineLocatePoint(
                            way.geom, interpolate_point.geom), 1)
-            FROM public.ways_tem;
+            FROM {schema}.ways_tem;
 
         end loop;
     raise notice 'Home connections are drawn successfully...';

--- a/pylovo/pgReaderWriter.py
+++ b/pylovo/pgReaderWriter.py
@@ -1312,7 +1312,7 @@ class PgReaderWriter:
         Updates ways_tem
         :return:
         """
-        query = f"""SELECT draw_way_connections();"""
+        query = """SELECT draw_way_connections();"""
         self.cur.execute(query)
 
     def calculate_sim_load(self, conn_list: Union[tuple, list]) -> Decimal:
@@ -2129,7 +2129,7 @@ class PgReaderWriter:
 
 
     def insert_plz_parameters(self, plz: int, trafo_string: str, load_count_string: str, bus_count_string: str):
-        update_query = f"""INSERT INTO plz_parameters (version_id, plz, trafo_num, load_count_per_trafo, bus_count_per_trafo)
+        update_query = """INSERT INTO plz_parameters (version_id, plz, trafo_num, load_count_per_trafo, bus_count_per_trafo)
         VALUES(%s, %s, %s, %s, %s);"""  # TODO: check - should values be updated for same plz and version if analysis is started? And Add a column
         self.cur.execute(
             update_query,
@@ -2177,7 +2177,7 @@ class PgReaderWriter:
         self.logger.info("analyse_cables finished.")
         cable_length_string = json.dumps(cable_length_dict)
 
-        update_query = f"""UPDATE plz_parameters
+        update_query = """UPDATE plz_parameters
         SET cable_length = %(c)s 
         WHERE version_id = %(v)s AND plz = %(p)s;"""
         self.cur.execute(
@@ -2296,7 +2296,7 @@ class PgReaderWriter:
         trafo_max_distance_string = json.dumps(trafo_max_distance_dict)
         trafo_avg_distance_string = json.dumps(trafo_avg_distance_dict)
 
-        update_query = f"""UPDATE plz_parameters
+        update_query = """UPDATE plz_parameters
         SET sim_peak_load_per_trafo = %(l)s, max_distance_per_trafo = %(m)s, avg_distance_per_trafo = %(a)s
         WHERE version_id = %(v)s AND plz = %(p)s;
         """
@@ -2314,7 +2314,7 @@ class PgReaderWriter:
         self.logger.debug("per trafo analysis finished")
 
     def read_trafo_dict(self, plz: int) -> dict:
-        read_query = f"""SELECT trafo_num FROM plz_parameters 
+        read_query = """SELECT trafo_num FROM plz_parameters 
         WHERE version_id = %(v)s AND plz = %(p)s;"""
         self.cur.execute(read_query, {"v": VERSION_ID, "p": plz})
         trafo_num_dict = self.cur.fetchall()[0][0]
@@ -2322,7 +2322,7 @@ class PgReaderWriter:
         return trafo_num_dict
 
     def read_per_trafo_dict(self, plz: int) -> tuple[list[dict], list[str], dict]:
-        read_query = f"""SELECT load_count_per_trafo, bus_count_per_trafo, sim_peak_load_per_trafo,
+        read_query = """SELECT load_count_per_trafo, bus_count_per_trafo, sim_peak_load_per_trafo,
         max_distance_per_trafo, avg_distance_per_trafo FROM plz_parameters 
         WHERE version_id = %(v)s AND plz = %(p)s;"""
         self.cur.execute(read_query, {"v": VERSION_ID, "p": plz})
@@ -2344,7 +2344,7 @@ class PgReaderWriter:
         return data_list, data_labels, trafo_dict
 
     def read_cable_dict(self, plz: int) -> dict:
-        read_query = f"""SELECT cable_length FROM plz_parameters
+        read_query = """SELECT cable_length FROM plz_parameters
         WHERE version_id = %(v)s AND plz = %(p)s;"""
         self.cur.execute(read_query, {"v": VERSION_ID, "p": plz})
         cable_length = self.cur.fetchall()[0][0]
@@ -2471,7 +2471,7 @@ class PgReaderWriter:
 
     def get_grid_versions_with_plz(self, plz: int) -> list[tuple]:
         query = (
-            f"""SELECT DISTINCT version_id FROM grid_result WHERE plz = %(p)s"""
+            """SELECT DISTINCT version_id FROM grid_result WHERE plz = %(p)s"""
         )
         self.cur.execute(query, {"p": plz})
         result = self.cur.fetchall()
@@ -2479,7 +2479,7 @@ class PgReaderWriter:
 
     def get_grids_of_version(self, plz: int, version_id: str) -> list[tuple]:
         query = (
-            f"""SELECT kcid, bcid, grid
+            """SELECT kcid, bcid, grid
                 FROM grid_result 
                 WHERE plz = %(p)s AND version_id = %(v)s""")
         self.cur.execute(query, {"p": plz, "v": version_id})
@@ -2572,7 +2572,7 @@ class PgReaderWriter:
 
     def delete_version_from_all_tables(self, version_id: str) -> None:
         """Delete all entries of the given version ID from all tables."""
-        query = f"DELETE FROM version WHERE version_id = %(v)s;"
+        query = "DELETE FROM version WHERE version_id = %(v)s;"
         self.cur.execute(query, {"v": version_id})
         self.conn.commit()
         self.logger.info(f"Version {version_id} deleted from all tables")
@@ -2584,7 +2584,7 @@ class PgReaderWriter:
 
         :param classification_id: ID of the classification version to delete
         """
-        query = f"DELETE FROM classification_version WHERE classification_id = %(cid)s;"
+        query = "DELETE FROM classification_version WHERE classification_id = %(cid)s;"
         self.cur.execute(query, {"cid": classification_id})
         self.conn.commit()
         
@@ -2607,7 +2607,7 @@ class PgReaderWriter:
 
     def get_clustering_parameters_for_plz_list(self, plz_tuple: tuple) -> pd.DataFrame:
         """get clustering parameter for multiple plz"""
-        query = f"""
+        query = """
                 WITH plz_table(plz) AS (
                     VALUES (%(p)s)
                 ),
@@ -2629,7 +2629,7 @@ class PgReaderWriter:
 
     def get_municipal_register_for_plz(self, plz: str) -> pd.DataFrame:
         """get entry of table municipal register for given PLZ"""
-        query = f"""SELECT * 
+        query = """SELECT * 
         FROM municipal_register
         WHERE plz = %(p)s;"""
         self.cur.execute(query, {"p": plz})
@@ -2639,7 +2639,7 @@ class PgReaderWriter:
 
     def get_municipal_register(self) -> pd.DataFrame:
         """get municipal register """
-        query = f"""SELECT * 
+        query = """SELECT * 
         FROM municipal_register;"""
         self.cur.execute(query)
         register = self.cur.fetchall()
@@ -2652,7 +2652,7 @@ class PgReaderWriter:
         :return: table with column of ags
         :rtype: DataFrame
          """
-        query = f"""SELECT * 
+        query = """SELECT * 
         FROM ags_log;"""
         df_query = pd.read_sql_query(query, con=self.conn, )
         return df_query

--- a/pylovo/pgReaderWriter.py
+++ b/pylovo/pgReaderWriter.py
@@ -40,6 +40,7 @@ class PgReaderWriter:
                 database=dbname, user=user, password=pw, host=host, port=port
             )
             self.cur = self.conn.cursor()
+            self.cur.execute(f"SET search_path TO {TARGET_SCHEMA}, public;")
             self.db_path = f"postgresql+psycopg2://{user}:{pw}@{host}:{port}/{dbname}"
             self.sqla_engine = create_engine(self.db_path)
         except pg.OperationalError as err:

--- a/pylovo/pgReaderWriter.py
+++ b/pylovo/pgReaderWriter.py
@@ -1329,7 +1329,6 @@ class PgReaderWriter:
 
         data = self.cur.fetchone()
         if data:
-            print("DEBUG: SCHEMA =", TARGET_SCHEMA, "| query result =", data)
             residential_load = Decimal(data[0])
             residential_count = Decimal(data[1])
             residential_factor = Decimal(data[2])

--- a/pylovo/pgReaderWriter.py
+++ b/pylovo/pgReaderWriter.py
@@ -37,12 +37,14 @@ class PgReaderWriter:
         )
         try:
             self.conn = pg.connect(
-                database=dbname, user=user, password=pw, host=host, port=port
+                database=dbname, user=user, password=pw, host=host, port=port, options=f"-c search_path={TARGET_SCHEMA},public"
             )
             self.cur = self.conn.cursor()
-            self.cur.execute(f"SET search_path TO {TARGET_SCHEMA}, public;")
             self.db_path = f"postgresql+psycopg2://{user}:{pw}@{host}:{port}/{dbname}"
-            self.sqla_engine = create_engine(self.db_path)
+            self.sqla_engine = create_engine(
+                self.db_path,
+                connect_args={"options": f"-c search_path={TARGET_SCHEMA},public"}
+                )
         except pg.OperationalError as err:
             self.logger.warning(
                 f"Connecting to {dbname} was not successful. Make sure, that you have established the SSH "
@@ -1327,6 +1329,7 @@ class PgReaderWriter:
 
         data = self.cur.fetchone()
         if data:
+            print("DEBUG: SCHEMA =", TARGET_SCHEMA, "| query result =", data)
             residential_load = Decimal(data[0])
             residential_count = Decimal(data[1])
             residential_factor = Decimal(data[2])

--- a/raw_data/municipal_register/join_regiostar_gemeindeverz.py
+++ b/raw_data/municipal_register/join_regiostar_gemeindeverz.py
@@ -5,6 +5,7 @@ from sqlalchemy import create_engine
 from raw_data.municipal_register.regiostar.import_regiostar import import_regiostar
 from raw_data.municipal_register.gemeindeverzeichnis.import_functions import import_plz_einwohner, import_zuordnung_plz
 from pylovo.config_loader import *
+from pylovo import pgReaderWriter as pg
 
 
 def import_tables() -> (pd.DataFrame, pd.DataFrame, pd.DataFrame):
@@ -33,21 +34,16 @@ def join_regiostar_plz(plz_pop: pd.DataFrame, plz_ags: pd.DataFrame, regiostar: 
 
 def municipal_register_to_db(regiostar_plz: pd.DataFrame) -> None:
     """writes register to database"""
-    conn = psycopg2.connect(database=DBNAME, user=USER, password=PASSWORD, host=HOST, port=PORT)
-    sqlalchemy_engine = create_engine(
-        f"postgresql+psycopg2://{USER}:{PASSWORD}@{HOST}:{PORT}/{DBNAME}")
-    cur = conn.cursor()
+    pgr = pg.PgReaderWriter()
     try:
         regiostar_plz.to_sql(
             'municipal_register', 
-            con=sqlalchemy_engine, 
+            con=pgr.sqla_engine, 
             if_exists='append', 
             index=False,
-            schema=TARGET_SCHEMA
         )
     except Exception as e:
         print(e)
-    conn.commit()
 
 
 def create_municipal_register() -> None:

--- a/raw_data/municipal_register/join_regiostar_gemeindeverz.py
+++ b/raw_data/municipal_register/join_regiostar_gemeindeverz.py
@@ -42,7 +42,8 @@ def municipal_register_to_db(regiostar_plz: pd.DataFrame) -> None:
             'municipal_register', 
             con=sqlalchemy_engine, 
             if_exists='append', 
-            index=False
+            index=False,
+            schema=TARGET_SCHEMA
         )
     except Exception as e:
         print(e)


### PR DESCRIPTION
As described in issue [37](https://github.com/tum-ens/pylovo/issues/37) schema selection for database writes/reads should be soft-coded to integrate the pylovo database into new infrastructure database.

###  Summary of Changes

The `target_schema` has been added to the **PostgreSQL search path** during the initialization of both the `PgReaderWriter` database connection and the SQLAlchemy engine. This is done via:

```sql
SET search_path TO {TARGET_SCHEMA}, public;
```

This configuration ensures that:

- The database will first look for tables, extensions, and other objects in the `{TARGET_SCHEMA}`.
- If an object is not found in `{TARGET_SCHEMA}`, it will fall back to the `public` schema.

###  Design Rationale

- All database connections are established through a central `PgReaderWriter` object.
- This object is responsible for applying the search path consistently.
- As a result:
  - **All connections are safe and trackable.**
  - **All queries automatically target the correct schema**—there is no need to specify the schema explicitly in each SQL statement.

###  Benefits

- Simplifies SQL queries by removing the need for schema qualification.
- Prevents accidental cross-schema queries or writes.
- Makes the codebase cleaner, safer, and easier to maintain.