### PR TITLE
Bugfix/fix unique osm id accross versions

### DIFF
--- a/classification/database_communication/DatabaseCommunication.py
+++ b/classification/database_communication/DatabaseCommunication.py
@@ -118,7 +118,7 @@ class DatabaseCommunication:
                 FROM transformer_positions tp
                 JOIN grid_result gr
                   ON tp.grid_result_id = gr.grid_result_id
-                WHERE version_id=%(v)s;"""
+                WHERE gr.version_id=%(v)s;"""
         params = {"v": VERSION_ID}
         df_transformer_positions = gpd.read_postgis(query, con=self.pgr.sqla_engine, params=params, )
         df_transformer_positions['geom'] = df_transformer_positions['geom'].apply(self.create_wkt_element)

--- a/pylovo/config_table_structure.py
+++ b/pylovo/config_table_structure.py
@@ -250,8 +250,14 @@ CREATE_QUERIES = {
     CREATE TABLE IF NOT EXISTS transformer_positions (
         grid_result_id bigint PRIMARY KEY,
         geom geometry(Point,3035),
-        osm_id varchar UNIQUE,
+        osm_id varchar,
+        version_id varchar,
         "comment" varchar,
+        CONSTRAINT uq_tp_osm_v UNIQUE (osm_id, version_id),
+        CONSTRAINT fk_tp_version_id
+            FOREIGN KEY (version_id)
+            REFERENCES grid_result (version_id)
+            ON DELETE CASCADE,
         CONSTRAINT fk_tp_grid_result_id
             FOREIGN KEY (grid_result_id)
             REFERENCES grid_result (grid_result_id)

--- a/pylovo/config_table_structure.py
+++ b/pylovo/config_table_structure.py
@@ -251,12 +251,12 @@ CREATE_QUERIES = {
         grid_result_id bigint PRIMARY KEY,
         geom geometry(Point,3035),
         osm_id varchar,
-        version_id varchar,
+        version_id varchar(10),
         "comment" varchar,
         CONSTRAINT uq_tp_osm_v UNIQUE (osm_id, version_id),
         CONSTRAINT fk_tp_version_id
             FOREIGN KEY (version_id)
-            REFERENCES grid_result (version_id)
+            REFERENCES version (version_id)
             ON DELETE CASCADE,
         CONSTRAINT fk_tp_grid_result_id
             FOREIGN KEY (grid_result_id)
@@ -345,7 +345,7 @@ CREATE_QUERIES = {
     """,
     "transformer_positions_with_grid": """
     CREATE OR REPLACE VIEW transformer_positions_with_grid AS (
-        SELECT tp.*, gr.version_id, gr.kcid, gr.bcid, gr.plz
+        SELECT tp.*, gr.kcid, gr.bcid, gr.plz
         FROM transformer_positions tp
         JOIN grid_result gr ON tp.grid_result_id = gr.grid_result_id
     )

--- a/pylovo/pgReaderWriter.py
+++ b/pylovo/pgReaderWriter.py
@@ -767,7 +767,7 @@ class PgReaderWriter:
                    FROM transformer_positions tp
                    JOIN grid_result gr
                    ON tp.grid_result_id = gr.grid_result_id
-                   WHERE version_id = %(v)s 
+                   WHERE gr.version_id = %(v)s 
                    AND plz = %(p)s 
                    AND kcid = %(k)s
                    AND bcid = %(b)s;"""

--- a/pylovo/pgReaderWriter.py
+++ b/pylovo/pgReaderWriter.py
@@ -950,8 +950,9 @@ class PgReaderWriter:
                    UPDATE grid_result SET model_status = 1 
                    WHERE version_id = %(v)s AND plz = %(p)s AND kcid = %(k)s AND bcid = %(b)s;
                    
-                   INSERT INTO transformer_positions (grid_result_id, geom, comment)
+                   INSERT INTO transformer_positions (version_id, grid_result_id, geom, comment)
                    VALUES (
+                     %(v)s,
                      (SELECT grid_result_id FROM grid_result WHERE version_id = %(v)s AND plz = %(p)s AND kcid = %(k)s AND bcid = %(b)s),
                      (SELECT the_geom FROM ways_tem_vertices_pgr WHERE id = %(c)s),
                      'on_way'
@@ -1288,8 +1289,9 @@ class PgReaderWriter:
             INSERT INTO grid_result (version_id, plz, kcid, bcid, ont_vertice_id, transformer_rated_power)
             VALUES (%(v)s, %(pc)s, %(k)s, %(count)s, %(t)s, %(l)s);
 
-            INSERT INTO transformer_positions (grid_result_id, geom, osm_id, comment)
+            INSERT INTO transformer_positions (version_id, grid_result_id, geom, osm_id, comment)
             VALUES (
+                %(v)s,
                 (SELECT grid_result_id FROM grid_result WHERE version_id = %(v)s AND plz = %(pc)s AND kcid = %(k)s AND bcid = %(count)s),
                 (SELECT center FROM buildings_tem WHERE vertice_id = %(t)s),
                 (SELECT osm_id FROM buildings_tem WHERE vertice_id = %(t)s),


### PR DESCRIPTION
Fixed issue where there was a unique contraint issue when generating the same grid in different versions.