### PR TITLE
adjust fetc_postcode function and multi grid generation bug fix

### DIFF
--- a/src/infdb/infdb_client.py
+++ b/src/infdb/infdb_client.py
@@ -85,18 +85,15 @@ class InfdbClient:
     
     def fetch_postcode_data(self) -> list[tuple]:
         """
-        Fetch postcode data from InfDB and return rows matching the local schema,
-        including geometry transformed to SRID 3035.
+        Fetch postcode data from {INFDB_SOURCE_SCHEMA} and return rows matching the local schema
         """
         query = """
-            SELECT 
-                plz,
-                note,
-                qkm,
-                einwohner AS population,
-                ST_Transform(geometry, 3035) AS geom
-            FROM opendata."plz_plz-5stellig";
+            SELECT * FROM postcode;
         """
         self.cur.execute(query)
-        return self.cur.fetchall()
+        rows = self.cur.fetchall()
+        if not rows:
+            raise ValueError("No postcode found in infdb")
+
+        return rows
 

--- a/src/ways_preprocessing_functions/core/generate_building_to_way_connections.sql
+++ b/src/ways_preprocessing_functions/core/generate_building_to_way_connections.sql
@@ -108,6 +108,7 @@ BEGIN
     -- =====================================================================================
     -- Group remaining connection points by the ways they will split
     -- This ensures each way is split only once, even with multiple connections
+    DROP TABLE IF EXISTS grouped_splits;
     CREATE TEMP TABLE grouped_splits AS
     SELECT 
         old_way_id,                           -- ID of way that will be split

--- a/src/ways_preprocessing_functions/core/generate_building_to_way_connections_infdb.sql
+++ b/src/ways_preprocessing_functions/core/generate_building_to_way_connections_infdb.sql
@@ -108,6 +108,7 @@ BEGIN
     -- =====================================================================================
     -- Group remaining connection points by the ways they will split
     -- This ensures each way is split only once, even with multiple connections
+    DROP TABLE IF EXISTS grouped_splits;
     CREATE TEMP TABLE grouped_splits AS
     SELECT 
         old_way_id,                           -- ID of way that will be split

--- a/src/ways_preprocessing_functions/utils/generate_building_way_connection_candidates.sql
+++ b/src/ways_preprocessing_functions/utils/generate_building_way_connection_candidates.sql
@@ -27,6 +27,7 @@ CREATE OR REPLACE FUNCTION generate_building_way_connection_candidates() RETURNS
 BEGIN
     -- MAIN PROCESSING: Create temporary table with comprehensive connection analysis
     -- This table will contain all necessary data for building-to-way connections
+    DROP TABLE IF EXISTS temp_building_connection_candidates;
     CREATE TEMP TABLE temp_building_connection_candidates AS
     
     -- CTE 1: FILTER BUILDINGS REQUIRING CONNECTIONS

--- a/src/ways_preprocessing_functions/utils/generate_building_way_connection_candidates_infdb.sql
+++ b/src/ways_preprocessing_functions/utils/generate_building_way_connection_candidates_infdb.sql
@@ -30,6 +30,7 @@ CREATE OR REPLACE FUNCTION generate_building_way_connection_candidates_infdb() R
 BEGIN
     -- MAIN PROCESSING: Create temporary table with comprehensive connection analysis
     -- This table will contain all necessary data for building-to-way connections
+    DROP TABLE IF EXISTS temp_building_connection_candidates_infdb;
     CREATE TEMP TABLE temp_building_connection_candidates_infdb AS
     
     -- CTE 1: FILTER BUILDINGS REQUIRING CONNECTIONS


### PR DESCRIPTION

### 1. Postcode Data Source Update

- **Old Behavior:**  
  Postcode data was fetched from `opendata."plz_plz-5stellig"` with hardcoded column mappings and on-the-fly transformation.

- **New Behavior:**  
  The postcode data is now directly retrieved from the `{INFDB_SOURCE_SCHEMA}.postcode` table, which should already contain pre-transformed and schema-compliant data.

---

### 2. Bug Fix: Drop Temporary Tables Before Creation

- **Issue:**  
  In grid generation for multiple postcodes, temporary table creation could fail if a relation with the same name already existed from a previous run.

- **Fix:**  
  Explicit `DROP TABLE IF EXISTS` statements were added before all `CREATE TEMP TABLE` statements in:
  - `generate_building_to_way_connections.sql`
  - `generate_building_to_way_connections_infdb.sql`
  - `generate_building_way_connection_candidates.sql`
  - `generate_building_way_connection_candidates_infdb.sql`

###  Files Changed

- `src/infdb/infdb_client.py`
- `src/ways_preprocessing_functions/core/generate_building_to_way_connections.sql`
- `src/ways_preprocessing_functions/core/generate_building_to_way_connections_infdb.sql`
- `src/ways_preprocessing_functions/utils/generate_building_way_connection_candidates.sql`
- `src/ways_preprocessing_functions/utils/generate_building_way_connection_candidates_infdb.sql`

---

